### PR TITLE
Feature/treetop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ build/
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
+.ruby-version
+
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem 'treetop'

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,6 @@
 source "https://rubygems.org"
 
 gem 'treetop'
+
+gem 'rspec'
+gem 'pry'

--- a/etc/tuna.treetop
+++ b/etc/tuna.treetop
@@ -1,0 +1,9 @@
+grammar Tuna
+  rule cat
+    'cat ' name <Cat>
+  end
+
+  rule name
+    [a-zA-Z]+
+  end
+end

--- a/lib/tuna.rb
+++ b/lib/tuna.rb
@@ -1,0 +1,8 @@
+require 'treetop'
+
+module Tuna
+  Treetop.load 'etc/tuna.treetop'
+
+  class Cat < Treetop::Runtime::SyntaxNode
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,13 @@
+require 'bundler/setup'
+require 'pry'
+
+require 'tuna'
+
+RSpec.configure do |config|
+  config.color = true
+  config.filter_run :focus => true
+  config.run_all_when_everything_filtered = true
+end
+
+Encoding.default_external = Encoding::UTF_8
+Encoding.default_internal = Encoding::UTF_8

--- a/spec/tuna_spec.rb
+++ b/spec/tuna_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+describe Tuna do
+end
+
+describe TunaParser do
+  it { is_expected.to be_a described_class }
+
+  it 'parses cats' do
+    expect(subject.parse('cat Fluffy')).to be_a Tuna::Cat
+  end
+end


### PR DESCRIPTION
This bootstraps a treetop parser, advancing #3.

Cats are declared with their name:

``` tuna
cat fluffy
```

The top-level concept here is a `Tuna::Cat`, which is probably not what we want. Let's think a bit about the domain model.
